### PR TITLE
Update specification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -724,6 +724,8 @@ dependencies = [
 [[package]]
 name = "testing-language-server"
 version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fae6ce9cb290e80814d1796e4207a0a0dc21c216807136d48b68c0f27be29b9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -747,9 +749,7 @@ dependencies = [
 
 [[package]]
 name = "testing-language-server"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fae6ce9cb290e80814d1796e4207a0a0dc21c216807136d48b68c0f27be29b9"
+version = "0.1.8"
 dependencies = [
  "anyhow",
  "chrono",
@@ -783,7 +783,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
- "testing-language-server 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "testing-language-server 0.1.7",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testing-language-server"
-version = "0.1.7"
+version = "0.1.8"
 edition = "2021"
 description = "LSP server for testing"
 license = "MIT"

--- a/src/server.rs
+++ b/src/server.rs
@@ -337,10 +337,11 @@ impl TestingLS {
             Ok(res) => {
                 for target_file in paths {
                     let diagnostics_for_file: Vec<Diagnostic> = res
+                        .data
                         .clone()
                         .into_iter()
-                        .filter(|RunFileTestResultItem { path, .. }| path == target_file)
-                        .flat_map(|RunFileTestResultItem { diagnostics, .. }| diagnostics)
+                        .filter(|FileDiagnostics { path, .. }| path == target_file)
+                        .flat_map(|FileDiagnostics { diagnostics, .. }| diagnostics)
                         .collect();
                     let uri = Url::from_file_path(target_file.replace("file://", "")).unwrap();
                     diagnostics.push((uri.to_string(), diagnostics_for_file));

--- a/src/server.rs
+++ b/src/server.rs
@@ -13,6 +13,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
 use std::process::Output;
+use testing_language_server::spec::DiscoverResult;
 
 const TOML_FILE_NAME: &str = ".testingls.toml";
 
@@ -413,7 +414,7 @@ impl TestingLS {
     #[allow(clippy::for_kv_map)]
     pub fn discover_file(&self, path: &str) -> Result<DiscoverResult, LSError> {
         let target_paths = vec![path.to_string()];
-        let mut result: DiscoverResult = vec![];
+        let mut result: DiscoverResult = DiscoverResult { data: vec![] };
         for WorkspaceAnalysis {
             adapter_config: adapter,
             workspaces,
@@ -423,7 +424,9 @@ impl TestingLS {
                 if !paths.contains(&path.to_string()) {
                     continue;
                 }
-                result.extend(self.discover(adapter, &target_paths)?);
+                result
+                    .data
+                    .extend(self.discover(adapter, &target_paths)?.data);
             }
         }
         Ok(result)

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -79,7 +79,10 @@ pub struct AdapterConfiguration {
 }
 
 /// Result of `<adapter command> detect-workspace`
-pub type DetectWorkspaceResult = HashMap<WorkspaceFilePath, Vec<FilePath>>;
+#[derive(Debug, Serialize, Clone, Deserialize)]
+pub struct DetectWorkspaceResult {
+    pub data: HashMap<WorkspaceFilePath, Vec<FilePath>>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct FileDiagnostics {
@@ -104,7 +107,7 @@ pub struct TestItem {
 }
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
-pub struct DiscoverResultItem {
+pub struct FoundFileTests {
     pub path: String,
     pub tests: Vec<TestItem>,
 }
@@ -112,5 +115,5 @@ pub struct DiscoverResultItem {
 /// Result of `<adapter command> discover`
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct DiscoverResult {
-    pub data: Vec<DiscoverResultItem>,
+    pub data: Vec<FoundFileTests>,
 }

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -110,4 +110,7 @@ pub struct DiscoverResultItem {
 }
 
 /// Result of `<adapter command> discover`
-pub type DiscoverResult = Vec<DiscoverResultItem>;
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
+pub struct DiscoverResult {
+    pub data: Vec<DiscoverResultItem>,
+}

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use lsp_types::Diagnostic;
 use lsp_types::Range;
+use lsp_types::ShowMessageParams;
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
@@ -80,14 +81,19 @@ pub struct AdapterConfiguration {
 /// Result of `<adapter command> detect-workspace`
 pub type DetectWorkspaceResult = HashMap<WorkspaceFilePath, Vec<FilePath>>;
 
-/// Result of `<adapter command> run-file-test`
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
-pub struct RunFileTestResultItem {
+pub struct FileDiagnostics {
     pub path: String,
     pub diagnostics: Vec<Diagnostic>,
 }
 
-pub type RunFileTestResult = Vec<RunFileTestResultItem>;
+/// Result of `<adapter command> run-file-test`
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct RunFileTestResult {
+    pub data: Vec<FileDiagnostics>,
+    #[serde(default)]
+    pub messages: Vec<ShowMessageParams>,
+}
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq)]
 pub struct TestItem {


### PR DESCRIPTION
#51 
Change array to object and add `data` field. This is necessary for extensibility.
The adapter will not work for a short time, but the adapter that supports the new interface has already been implemented in the `feat/update-spec` branch, so we will cherry-pick it and release the new version of the adapter as soon as the server is released.
